### PR TITLE
Add ExperimentalRiveCmpApi annotation

### DIFF
--- a/library/src/androidMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.android.kt
+++ b/library/src/androidMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.android.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import app.rive.runtime.kotlin.RiveAnimationView
 import app.rive.runtime.kotlin.core.Alignment
+import dev.muazkadan.rivecmp.utils.ExperimentalRiveCmpApi
 
+@ExperimentalRiveCmpApi
 @Composable
 actual fun CustomRiveAnimation(
     modifier: Modifier,

--- a/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.kt
+++ b/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.kt
@@ -2,7 +2,9 @@ package dev.muazkadan.rivecmp
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import dev.muazkadan.rivecmp.utils.ExperimentalRiveCmpApi
 
+@ExperimentalRiveCmpApi
 @Composable
 expect fun CustomRiveAnimation(
     modifier: Modifier = Modifier,

--- a/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/utils/ExperimentalRiveCmpApi.kt
+++ b/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/utils/ExperimentalRiveCmpApi.kt
@@ -1,0 +1,16 @@
+package dev.muazkadan.rivecmp.utils
+
+/**
+ * Marks declarations that are still **experimental** in the Rive CMP library.
+ * 
+ * These APIs are in early development and may change significantly or be removed entirely
+ * in future releases. They are not recommended for production use.
+ */
+@RequiresOptIn(
+    message = "This API is experimental and may change or be removed in future versions. " +
+            "Use with caution in production code.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class ExperimentalRiveCmpApi

--- a/library/src/iosMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.ios.kt
+++ b/library/src/iosMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.ios.kt
@@ -7,9 +7,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitView
+import dev.muazkadan.rivecmp.utils.ExperimentalRiveCmpApi
 import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
+@ExperimentalRiveCmpApi
 @Composable
 actual fun CustomRiveAnimation(
     modifier: Modifier,


### PR DESCRIPTION
Adds a custom @ExperimentalRiveCmpApi annotation to mark the library's APIs as experimental, providing clear warnings to developers about the early state of the library.
