### PR TITLE
bump spmForKmp version to 0.11.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ compose-activity = "1.10.1"
 androidx-lifecycle = "2.9.0"
 rive-android = "10.1.5"
 androidx-startup = "1.2.0"
-spmForKmp = "0.11.1"
+spmForKmp = "0.11.2"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
bump [spm4Kmp](https://github.com/frankois944/spm4Kmp) version to 0.11.2

### Release Notes: 

- The bridge source directory is now a symbolic link inside the SPM working directory instead of a copy [#122](https://github.com/frankois944/spm4Kmp/pull/122)
- Update the Gradle cache condition for the copy package resources task.
