### PR TITLE
add input support for Rive animations

### DIFF
--- a/library/src/androidMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.android.kt
+++ b/library/src/androidMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.android.kt
@@ -14,6 +14,77 @@ import dev.muazkadan.rivecmp.utils.ExperimentalRiveCmpApi
 @Composable
 actual fun CustomRiveAnimation(
     modifier: Modifier,
+    composition: RiveComposition?,
+    alignment: RiveAlignment,
+    autoPlay: Boolean,
+    artboardName: String?,
+    fit: RiveFit,
+    stateMachineName: String?
+) {
+    if (composition != null) {
+        when (val spec = composition.spec) {
+            is RiveUrlCompositionSpec -> {
+                AndroidView(
+                    modifier = modifier,
+                    factory = { context ->
+                        val builder = RiveAnimationView.Builder(context)
+                            .setResource(spec.url)
+                            .setAlignment(alignment.toAndroidAlignment())
+                            .setFit(fit.toAndroidFit())
+                            .setAutoplay(autoPlay)
+
+                        // Set artboard name if provided
+                        artboardName?.let {
+                            builder.setArtboardName(it)
+                        }
+
+                        // Set state machine name if provided
+                        stateMachineName?.let {
+                            builder.setStateMachineName(it)
+                        }
+
+                        builder.build()
+                    },
+                    update = { view ->
+                        composition.connectToAnimationView(view)
+                    }
+                )
+            }
+            is RiveByteArrayCompositionSpec -> {
+                AndroidView(
+                    modifier = modifier,
+                    factory = { context ->
+                        val builder = RiveAnimationView.Builder(context)
+                            .setResource(spec.byteArray)
+                            .setAlignment(alignment.toAndroidAlignment())
+                            .setFit(fit.toAndroidFit())
+                            .setAutoplay(autoPlay)
+
+                        // Set artboard name if provided
+                        artboardName?.let {
+                            builder.setArtboardName(it)
+                        }
+
+                        // Set state machine name if provided
+                        stateMachineName?.let {
+                            builder.setStateMachineName(it)
+                        }
+
+                        builder.build()
+                    },
+                    update = { view ->
+                        composition.connectToAnimationView(view)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@ExperimentalRiveCmpApi
+@Composable
+actual fun CustomRiveAnimation(
+    modifier: Modifier,
     url: String,
     alignment: RiveAlignment,
     autoPlay: Boolean,

--- a/library/src/androidMain/kotlin/dev/muazkadan/rivecmp/RiveComposition.android.kt
+++ b/library/src/androidMain/kotlin/dev/muazkadan/rivecmp/RiveComposition.android.kt
@@ -1,0 +1,35 @@
+package dev.muazkadan.rivecmp
+
+import app.rive.runtime.kotlin.RiveAnimationView
+import java.lang.ref.WeakReference
+
+actual class RiveComposition internal actual constructor(
+    spec: RiveCompositionSpec
+) {
+    internal actual val spec: RiveCompositionSpec = spec
+    private var animationViewRef: RiveAnimationView? = null
+
+    actual fun setNumberInput(stateMachineName: String, name: String, value: Float) {
+        animationViewRef?.setNumberState(
+            stateMachineName = stateMachineName,
+            inputName = name,
+            value = value
+        )
+    }
+
+    actual fun setBooleanInput(stateMachineName: String, name: String, value: Boolean) {
+        animationViewRef?.setBooleanState(
+            stateMachineName = stateMachineName,
+            inputName = name,
+            value = value
+        )
+    }
+
+    actual fun setTriggerInput(stateMachineName: String, name: String) {
+        animationViewRef?.fireState(stateMachineName = stateMachineName, inputName = name)
+    }
+
+    internal actual fun connectToAnimationView(animationView: Any?) {
+        animationViewRef = animationView as? RiveAnimationView
+    }
+} 

--- a/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.kt
+++ b/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.kt
@@ -8,43 +8,15 @@ import dev.muazkadan.rivecmp.utils.ExperimentalRiveCmpApi
 
 @ExperimentalRiveCmpApi
 @Composable
-fun CustomRiveAnimation(
-    composition: RiveComposition?,
+expect fun CustomRiveAnimation(
     modifier: Modifier = Modifier,
+    composition: RiveComposition?,
     alignment: RiveAlignment = RiveAlignment.CENTER,
     autoPlay: Boolean = true,
     artboardName: String? = null,
     fit: RiveFit = RiveFit.CONTAIN,
     stateMachineName: String? = null,
-) {
-    if (composition != null) {
-        when (val spec = composition.spec) {
-            is RiveUrlCompositionSpec -> {
-                CustomRiveAnimation(
-                    modifier = modifier,
-                    url = spec.url,
-                    alignment = alignment,
-                    autoPlay = autoPlay,
-                    artboardName = artboardName,
-                    fit = fit,
-                    stateMachineName = stateMachineName
-                )
-            }
-
-            is RiveByteArrayCompositionSpec -> {
-                CustomRiveAnimation(
-                    modifier = modifier,
-                    byteArray = spec.byteArray,
-                    alignment = alignment,
-                    autoPlay = autoPlay,
-                    artboardName = artboardName,
-                    fit = fit,
-                    stateMachineName = stateMachineName
-                )
-            }
-        }
-    }
-}
+)
 
 @ExperimentalRiveCmpApi
 @Composable

--- a/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/RiveComposition.kt
+++ b/library/src/commonMain/kotlin/dev/muazkadan/rivecmp/RiveComposition.kt
@@ -35,6 +35,14 @@ fun rememberRiveComposition(
     return result
 }
 
-class RiveComposition internal constructor(
+expect class RiveComposition internal constructor(
+    spec: RiveCompositionSpec
+) {
     internal val spec: RiveCompositionSpec
-)
+
+    fun setNumberInput(stateMachineName: String, name: String, value: Float)
+    fun setBooleanInput(stateMachineName: String, name: String, value: Boolean)
+    fun setTriggerInput(stateMachineName: String, name: String)
+
+    internal fun connectToAnimationView(animationView: Any?)
+}

--- a/library/src/iosMain/kotlin/dev/muazkadan/rivecmp/RiveComposition.ios.kt
+++ b/library/src/iosMain/kotlin/dev/muazkadan/rivecmp/RiveComposition.ios.kt
@@ -1,0 +1,30 @@
+package dev.muazkadan.rivecmp
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import nativeIosShared.RiveAnimationController
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.WeakReference
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+actual class RiveComposition internal actual constructor(
+    spec: RiveCompositionSpec
+) {
+    internal actual val spec: RiveCompositionSpec = spec
+    private var controllerRef: RiveAnimationController? = null
+
+    actual fun setNumberInput(stateMachineName: String, name: String, value: Float) {
+        controllerRef?.setNumberInput(name, value)
+    }
+
+    actual fun setBooleanInput(stateMachineName: String, name: String, value: Boolean) {
+        controllerRef?.setBooleanInput(name, value)
+    }
+
+    actual fun setTriggerInput(stateMachineName: String, name: String) {
+        controllerRef?.setTriggerInput(name)
+    }
+
+    internal actual fun connectToAnimationView(animationView: Any?) {
+        controllerRef = animationView as? RiveAnimationController
+    }
+} 

--- a/library/src/swift/nativeIosShared/RiveAnimationController.swift
+++ b/library/src/swift/nativeIosShared/RiveAnimationController.swift
@@ -145,4 +145,16 @@ import RiveRuntime
         viewModel = nil
         pendingConfiguration = nil
     }
+    
+    public func setNumberInput(_ name: String, _ value: Float) {
+        viewModel?.setInput(name, value: value)
+    }
+    
+    public func setBooleanInput(_ name: String, _ value: Bool) {
+        viewModel?.setInput(name, value: value)
+    }
+    
+    public func setTriggerInput(_ name: String) {
+        viewModel?.triggerInput(name)
+    }
 }


### PR DESCRIPTION
This PR introduces the ability to interact with Rive state machines by setting number, boolean, and trigger inputs.

**Key changes include:**

- Added `setNumberInput`, `setBooleanInput`, and `setTriggerInput` methods to `RiveComposition` for both Android and iOS.
- Updated `RiveAnimationController.swift` to expose corresponding input methods.
