### PR TITLE
Migrate spmForKmp to 1.0.0-Beta01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ compose-activity = "1.10.1"
 androidx-lifecycle = "2.9.1"
 rive-android = "10.2.1"
 androidx-startup = "1.2.0"
-spmForKmp = "0.11.3"
+spmForKmp = "1.0.0-Beta01"
 pullrefresh = "1.4.0-beta03"
 dokka = "2.0.0"
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -116,7 +116,7 @@ swiftPackageConfig {
         minIos = "14.0"
         spmWorkingPath =
             "${projectDir.resolve("SPM")}" // change the Swift Package Manager working Dir
-        copyDependenciesToApp = true
+        exportedPackageSettings { includeProduct = listOf("RiveRuntime") }
         dependency {
             remotePackageVersion(
                 url = URI("https://github.com/rive-app/rive-ios.git"),


### PR DESCRIPTION
This PR updates the SPM for KMP dependency to version 1.0.0-Beta01.