### PR TITLE
Bump kotlin version to 2.2.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.12.0"
-kotlin = "2.2.10"
+kotlin = "2.2.21"
 android-minSdk = "24"
 android-compileSdk = "36"
 compose-multiplatform = "1.8.2"


### PR DESCRIPTION
Bump kotlin version to 2.2.21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Kotlin version in `gradle/libs.versions.toml` from 2.2.10 to 2.2.21.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a85279c32dad6355745be22c75f4bd4343f9d0b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->