### PR TITLE
fix Snizzors crash with Compose Multiplatform 1.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidx-startup = "1.2.0"
 spmForKmp = "1.4.0"
 pullrefresh = "1.4.0-beta03"
 dokka = "2.0.0"
-snizzors = "1.0.0"
+snizzors = "1.0.0-cmp1.9"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `snizzors` version in `gradle/libs.versions.toml` from `1.0.0` to `1.0.0-cmp1.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f329dd5d4242ed0d2cf597bc32d1ba0e0a734500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->