### PR TITLE
Update rive-ios dependency version to 6.12.3

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
             dependency {
                 remotePackageVersion(
                     url = uri("https://github.com/rive-app/rive-ios.git"),
-                    version = "6.11.1",
+                    version = "6.12.3",
                     products = {
                         add("RiveRuntime", exportToKotlin = true)
                     },

--- a/library/exportedNativeIosShared/Package.swift
+++ b/library/exportedNativeIosShared/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version: 5.9
 
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(
     name: "exportedNativeIosShared",
-    platforms: [.iOS("14.0"), .macOS("10.13"), .tvOS("12.0"), .watchOS("4.0")],
+    platforms: [.iOS("14.0"),.macOS("10.13"),.tvOS("12.0"),.watchOS("4.0")],
     products: [
         .library(
             name: "exportedNativeIosShared",
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["exportedNativeIosShared"])
     ],
     dependencies: [
-        .package(url: "https://github.com/rive-app/rive-ios.git", exact: "6.11.1")
+        .package(url: "https://github.com/rive-app/rive-ios.git", exact: "6.12.3")
     ],
     targets: [
         .target(
@@ -21,9 +21,9 @@ let package = Package(
                 .product(name: "RiveRuntime", package: "rive-ios")
             ],
             path: "Sources"
-
+            
         )
-
+        
     ]
 )
         


### PR DESCRIPTION
- Update rive-ios dependency version to 6.12.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update rive-ios (RiveRuntime) dependency to 6.12.3 in Kotlin Multiplatform SPM config and exported Swift package.
> 
> - **Dependencies**:
>   - Bump `rive-ios` (`RiveRuntime`) from `6.11.1` to `6.12.3`.
>     - In `library/build.gradle.kts` SPM config for `nativeIosShared` exporting `RiveRuntime`.
>     - In `library/exportedNativeIosShared/Package.swift` SPM dependency pinned to `exact: 6.12.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6633e2c6ad49e3ceca99fadb5c8f69862ed200e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->