### PR TITLE
replace SnizzorsUIView with UIKitView

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -77,7 +77,7 @@ kotlin {
         }
 
         iosMain.dependencies {
-            implementation(libs.snizzors)
+//            implementation(libs.snizzors)
         }
 
         jsMain.dependencies {

--- a/library/src/iosMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.ios.kt
+++ b/library/src/iosMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.ios.kt
@@ -3,8 +3,10 @@ package dev.muazkadan.rivecmp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import com.infiniteretry.snizzors.SnizzorsUIView
+import androidx.compose.ui.viewinterop.UIKitInteropProperties
+import androidx.compose.ui.viewinterop.UIKitView
 import dev.muazkadan.rivecmp.core.RiveAlignment
 import dev.muazkadan.rivecmp.core.RiveFit
 import dev.muazkadan.rivecmp.core.toIosAlignment
@@ -18,7 +20,7 @@ import nativeIosShared.RiveAnimationController
 import platform.Foundation.NSData
 import platform.Foundation.create
 
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalComposeUiApi::class)
 @ExperimentalRiveCmpApi
 @Composable
 actual fun CustomRiveAnimation(
@@ -55,14 +57,15 @@ actual fun CustomRiveAnimation(
                     }
                 }
 
-                SnizzorsUIView(
+                UIKitView(
                     factory = {
                         animationController.createAnimationView()
                     },
                     modifier = modifier,
                     update = { view ->
                         animationController.updateView(view)
-                    }
+                    },
+                    properties = UIKitInteropProperties(placedAsOverlay = true)
                 )
             }
             is RiveByteArrayCompositionSpec -> {
@@ -97,21 +100,22 @@ actual fun CustomRiveAnimation(
                     }
                 }
 
-                SnizzorsUIView(
+                UIKitView(
                     factory = {
                         animationController.createAnimationView()
                     },
                     modifier = modifier,
                     update = { view ->
                         animationController.updateView(view)
-                    }
+                    },
+                    properties = UIKitInteropProperties(placedAsOverlay = true)
                 )
             }
         }
     }
 }
 
-@OptIn(ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class, ExperimentalComposeUiApi::class)
 @ExperimentalRiveCmpApi
 @Composable
 actual fun CustomRiveAnimation(
@@ -142,19 +146,20 @@ actual fun CustomRiveAnimation(
         }
     }
 
-    SnizzorsUIView(
+    UIKitView(
         factory = {
             animationController.createAnimationView()
         },
         modifier = modifier,
         update = { view ->
             animationController.updateView(view)
-        }
+        },
+        properties = UIKitInteropProperties(placedAsOverlay = true)
     )
 }
 
 
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalComposeUiApi::class)
 @ExperimentalRiveCmpApi
 @Composable
 actual fun CustomRiveAnimation(
@@ -194,13 +199,14 @@ actual fun CustomRiveAnimation(
         }
     }
 
-    SnizzorsUIView(
+    UIKitView(
         factory = {
             animationController.createAnimationView()
         },
         modifier = modifier,
         update = { view ->
             animationController.updateView(view)
-        }
+        },
+        properties = UIKitInteropProperties(placedAsOverlay = true)
     )
 }


### PR DESCRIPTION
## What's new: 
- Remove `snizzors` dependency from `iosMain`.
- Replace `SnizzorsUIView` with standard `UIKitView` in `CustomRiveAnimation.ios.kt`.
- Set `UIKitInteropProperties(placedAsOverlay = true)` for the interop view.
- Add `ExperimentalComposeUiApi` opt-in to support the new interop properties.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **iOS interop simplification**
> 
> - Replaces `SnizzorsUIView` with standard `UIKitView` in `CustomRiveAnimation.ios.kt` and adds `UIKitInteropProperties(placedAsOverlay = true)`
> - Adds `ExperimentalComposeUiApi` opt-in to affected composables to enable new interop properties
> - Comments out `iosMain` dependency on `snizzors` in `build.gradle.kts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c420fbbf5dceff61d9ae84c474187654314a7b2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->