### PR TITLE
update rive-ios to 6.13.0

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
             dependency {
                 remotePackageVersion(
                     url = uri("https://github.com/rive-app/rive-ios.git"),
-                    version = "6.12.3",
+                    version = "6.13.0",
                     products = {
                         add("RiveRuntime", exportToKotlin = true)
                     },

--- a/library/exportedNativeIosShared/Package.swift
+++ b/library/exportedNativeIosShared/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["exportedNativeIosShared"])
     ],
     dependencies: [
-        .package(url: "https://github.com/rive-app/rive-ios.git", exact: "6.12.3")
+        .package(url: "https://github.com/rive-app/rive-ios.git", exact: "6.13.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
The rive-ios dependency version has been updated from 6.12.3 to 6.13.0 in the Gradle build script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates iOS dependency versions to align with rive-ios 6.13.0.
> 
> - Bumps `rive-ios`/`RiveRuntime` from `6.12.3` to `6.13.0` in `library/build.gradle.kts` SwiftPM config for iOS targets
> - Mirrors the version bump in `library/exportedNativeIosShared/Package.swift` dependencies
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d09a54c56dec6ab7ca05eff5eee496411071be5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->