### PR TITLE
update npm @rive-app/canvas dependency to 2.34.1

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -81,7 +81,7 @@ kotlin {
         }
 
         jsMain.dependencies {
-            implementation(npm("@rive-app/canvas", "2.31.1"))
+            implementation(npm("@rive-app/canvas", "2.34.1"))
         }
     }
 }


### PR DESCRIPTION
Bump @rive-app/canvas version from 2.31.1 to 2.34.1 in jsMain dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Updates npm dependency `@rive-app/canvas` in `jsMain.dependencies` from `2.31.1` to `2.34.1` in `library/build.gradle.kts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe843ab85213cb188121bfe773b7f8c93d2b3013. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->