### PR TITLE
Bump com.vanniktech.maven.publish to 0.36.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ snizzors = { group = "com.infiniteretry.snizzors", name = "snizzors", version.re
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.35.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 spmForKmp = { id = "io.github.frankois944.spmForKmp", version.ref = "spmForKmp" }


### PR DESCRIPTION
### Motivation
- Update the `com.vanniktech.maven.publish` plugin to `0.36.0` to pick up upstream fixes and improvements.

### Description
- Bumped the plugin entry in `gradle/libs.versions.toml` from `0.35.0` to `0.36.0`.

### Testing
- No automated tests were run for this version-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776ad121cc83328e6d77b9fb9f3f7c)