### PR TITLE
Fix desktop colour swap and make the native runtime reproducible

### DIFF
--- a/.github/workflows/build-native-desktop.yml
+++ b/.github/workflows/build-native-desktop.yml
@@ -1,0 +1,89 @@
+name: Build native desktop runtime
+
+# Deliberately NOT run on every push/PR: this builds Skia and the Rive C++ runtime
+# from source and takes a long time, while the output only changes when the JNI
+# bridge or the pinned rive-runtime commit changes.
+on:
+  workflow_dispatch:
+    inputs:
+      upload_only:
+        description: "Build and upload the artifact without failing on checksum drift"
+        type: boolean
+        default: false
+  push:
+    tags:
+      - "v*"
+  schedule:
+    # Monthly drift check: does the pinned commit still build and pass the smoke test?
+    - cron: "0 4 1 * *"
+
+jobs:
+  build:
+    # macOS 15 runners are arm64, matching the shipped librive-desktoparm64.dylib.
+    runs-on: macos-15
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Record the pinned rive-runtime commit
+        run: |
+          git -C submodules/rive-runtime rev-parse HEAD | tee pinned-rive-runtime.txt
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 24
+
+      - name: Install native build tools
+        run: brew install ninja premake
+
+      - name: Build Skia for arm64
+        working-directory: submodules/rive-runtime/skia/dependencies
+        run: ./make_skia_macos.sh arm64
+
+      - name: Configure
+        run: cmake -B native/rive-desktop/build -S native/rive-desktop -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build native/rive-desktop/build
+
+      - name: Fingerprint the freshly built binary
+        id: fingerprint
+        run: |
+          BIN=$(find native/rive-desktop/build -name 'librive-desktoparm64.dylib' | head -1)
+          echo "Built: $BIN"
+          shasum -a 256 "$BIN" | tee built.sha256
+          echo "path=$BIN" >> "$GITHUB_OUTPUT"
+
+      - name: Run the JNI smoke test against the freshly built binary
+        run: |
+          cp "${{ steps.fingerprint.outputs.path }}" \
+             runtime-macos-arm64/src/main/resources/librive-desktoparm64.dylib
+          ./gradlew :library:jvmTest --rerun-tasks
+
+      - name: Compare against the committed binary
+        if: ${{ !inputs.upload_only }}
+        run: |
+          # The committed dylib predates the pin and is not expected to match yet.
+          # Once it has been replaced by an artifact from this workflow, a mismatch
+          # here means the pinned commit or the bridge changed without the binary
+          # and its checksum in native/rive-desktop/README.md being updated.
+          COMMITTED=$(git show HEAD:runtime-macos-arm64/src/main/resources/librive-desktoparm64.dylib | shasum -a 256 | cut -d' ' -f1)
+          BUILT=$(cut -d' ' -f1 < built.sha256)
+          echo "committed: $COMMITTED"
+          echo "built:     $BUILT"
+          if [ "$COMMITTED" != "$BUILT" ]; then
+            echo "::warning::Built binary differs from the committed one. If this is the first authoritative build, replace the committed dylib with this artifact and update the checksum in native/rive-desktop/README.md."
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: librive-desktoparm64
+          path: |
+            ${{ steps.fingerprint.outputs.path }}
+            built.sha256
+            pinned-rive-runtime.txt
+          if-no-files-found: error

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "submodules/rive-runtime"]
 	path = submodules/rive-runtime
 	url = https://github.com/rive-app/rive-runtime.git
-	branch = main

--- a/library/src/jvmMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.jvm.kt
+++ b/library/src/jvmMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.jvm.kt
@@ -24,6 +24,8 @@ import dev.muazkadan.rivecmp.utils.ExperimentalRiveCmpApi
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.impl.BufferUtil
 
@@ -172,7 +174,13 @@ private class RiveRendererNode(
 
         bitmap?.close()
         bitmap = Bitmap()
-            .apply { allocPixels(ImageInfo.makeN32Premul(size.width, size.height)) }
+            .apply {
+                // The native bridge links its own Skia build, whose kN32_SkColorType
+                // need not match Skiko's N32. Pin both sides to an explicit order.
+                allocPixels(
+                    ImageInfo(size.width, size.height, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
+                )
+            }
             .also { imageBitmap = it.asComposeImageBitmap() }
         bindBuffer()
     }

--- a/native/rive-desktop/README.md
+++ b/native/rive-desktop/README.md
@@ -30,11 +30,43 @@ paths for macOS x64, Linux, and Windows, but they're unverified — building for
 those requires their own toolchains and a prebuilt Skia checkout for that
 platform. Contributions welcome.
 
-## Note on the `submodules/rive-runtime` pin
+## The `submodules/rive-runtime` pin
 
-The submodule currently tracks `rive-app/rive-runtime`'s `main` branch tip as of
-when this was added. The exact upstream commit the shipped prebuilt binary was
-originally built against wasn't recorded precisely enough to pin here — if you
-rebuild from a different `rive-runtime` commit than the one used for the prebuilt
-`.dylib`, your local build may produce a binary that behaves slightly differently
-from the one currently bundled.
+The submodule is pinned to an exact commit:
+
+```
+073942e9261faa2f886fea733505751a131b6a1f
+```
+
+`.gitmodules` deliberately declares no `branch`, so `git submodule update --remote`
+cannot silently move the pin. Changing which upstream commit we build against should
+be a deliberate, reviewable commit that updates the gitlink and the checksum below.
+
+## Provenance of the shipped binary
+
+The prebuilt `runtime-macos-arm64/src/main/resources/librive-desktoparm64.dylib`
+currently in this repository has this fingerprint:
+
+```
+sha256  baf660c9323d08239e464278cbcec2ffa4bc5129658473a5f8477f3bb5a2aab3
+size    9191704 bytes
+```
+
+> [!WARNING]
+> **This binary predates the pin above and is not reproducible from this repository.**
+> It was built before the exact `rive-runtime` commit was recorded, so rebuilding from
+> the pinned commit may produce a binary that behaves slightly differently. The
+> checksum here identifies *what we currently ship*, not that it matches this source.
+>
+> To close this gap, run the **Build native desktop runtime** workflow
+> (`.github/workflows/build-native-desktop.yml`), which builds the dylib from the
+> pinned commit on a clean macOS arm64 runner and runs the JNI smoke test against it.
+> Replace the committed binary with that artifact and update the checksum above; the
+> warning can then be removed.
+
+Whenever the binary is replaced, update the checksum in this file in the same commit.
+Verify a copy with:
+
+```sh
+shasum -a 256 runtime-macos-arm64/src/main/resources/librive-desktoparm64.dylib
+```


### PR DESCRIPTION
Follow-up to #148. Two independent issues found while testing the desktop target against the sample.

## 🎨 Red/blue channel swap in desktop rendering

Rive animations on JVM/Desktop rendered with red and blue transposed against every other platform. Comparing the same sample side by side, every colour was an exact R↔B swap:

| | iOS | Desktop (before) |
|---|---|---|
| Van background | pink `(226,43,90)` | purple `(90,43,226)` |
| Jeep background | cyan `(0,200,220)` | yellow `(220,200,0)` |
| Toggle knob | yellow `(250,210,60)` | light blue `(60,210,250)` |

**Cause.** Both sides of the JNI boundary ask for the "native" 32-bit colour type — `ImageInfo.makeN32Premul` in Kotlin, `SkImageInfo::MakeN32Premul` in the bridge — which reads as obviously consistent. But `kN32_SkColorType` is a compile-time alias resolved per Skia build, and there are two different builds here: **Skiko** allocates the bitmap, the **bridge's own Skia checkout** writes into it. They disagreed, so the bridge wrote RGBA into memory Skiko read as BGRA.

**Fix.** Allocate the bitmap with an explicit `RGBA_8888` colour type so it matches what the bridge writes, instead of relying on two independent Skia builds agreeing on what "native" means.

Verified on macOS arm64: desktop output now matches iOS.

> [!NOTE]
> This compiles, passes the JNI smoke test, and runs without logging anything — it was only findable by looking at the rendered output.

## 🔒 Provenance of the prebuilt native binary

`runtime-macos-arm64/.../librive-desktoparm64.dylib` (9.2 MB) is published to Maven Central inside the runtime artifact but is **not reproducible from this repository** — per the native README, it was built before the exact `rive-runtime` commit was recorded.

- Drop `branch = main` from `.gitmodules` so `git submodule update --remote` cannot silently move the pin. The gitlink already pins `073942e9261faa2f886fea733505751a131b6a1f`.
- Document that pin and fingerprint the currently shipped binary (`sha256 baf660c9…aab3`, 9,191,704 bytes), with an explicit warning that the checksum identifies *what we ship*, not that it matches this source.
- Add `.github/workflows/build-native-desktop.yml`: builds Skia and the bridge from the pinned commit on a clean macOS arm64 runner, runs the JNI smoke test against the result, and uploads the binary with its checksum.

The workflow is deliberately **not** per-PR — it builds Skia from source, and the output only changes when the bridge or the pin changes. Triggers are `workflow_dispatch`, version tags, and a monthly drift check.

> [!IMPORTANT]
> **The workflow has never been run.** It is structurally sound and its paths match `CMakeLists.txt`, but `make_skia_macos.sh` on a hosted runner is where it would fail first. Expect to iterate on the first dispatch. Running it once and replacing the committed dylib with its artifact is what actually closes the provenance gap; this PR only puts the mechanism in place.

## Not addressed here

Both are C++ changes needing a native rebuild, and matter when Linux/Windows land:

- **The colour fix is macOS arm64-shaped.** It matches Kotlin to what *this* prebuilt dylib writes. Another platform's Skia build may resolve `N32` differently and the swap returns inverted. The durable fix is to pass the colour type across the JNI boundary rather than each side assuming.
- **Latent rowBytes assumption.** `canvas_renderer.hpp` hardcodes `width * 4` as the row stride while Kotlin sizes the buffer as `bitmap.rowBytes * bitmap.height`. If Skia ever pads rows for alignment the render will skew — the same class of "two sides assuming the same layout" mistake as the colour bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop rendering consistency by explicitly standardizing bitmap color and alpha formats.

* **Documentation**
  * Documented the exact native runtime version used by desktop builds.
  * Added verification details for the shipped desktop binary, including its checksum and size.
  * Added instructions for rebuilding and validating the native desktop runtime.

* **Chores**
  * Added an automated process for building, testing, fingerprinting, and publishing native desktop runtime artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->