### PR TITLE
Make the native desktop runtime actually buildable in CI

### DIFF
--- a/.github/workflows/build-native-desktop.yml
+++ b/.github/workflows/build-native-desktop.yml
@@ -19,8 +19,11 @@ on:
 
 jobs:
   build:
-    # macOS 15 runners are arm64, matching the shipped librive-desktoparm64.dylib.
-    runs-on: macos-15
+    # macOS 14 runners are arm64 (matching the shipped librive-desktoparm64.dylib)
+    # and ship an older Xcode/SDK. The Skia checkout pinned by rive-runtime vendors
+    # a zlib whose `#define fdopen(fd,mode) NULL` breaks against the macOS 15.5 SDK's
+    # own fdopen declaration, so the newer image cannot build it.
+    runs-on: macos-14
     timeout-minutes: 120
 
     steps:
@@ -36,6 +39,13 @@ jobs:
         with:
           distribution: temurin
           java-version: 24
+
+      - name: Report the active toolchain
+        run: |
+          echo "Available Xcode versions:"
+          ls -d /Applications/Xcode*.app 2>/dev/null || true
+          xcodebuild -version || true
+          xcrun --show-sdk-version || true
 
       - name: Install native build tools
         run: brew install ninja premake

--- a/.github/workflows/build-native-desktop.yml
+++ b/.github/workflows/build-native-desktop.yml
@@ -52,7 +52,15 @@ jobs:
 
       - name: Build Skia for arm64
         working-directory: submodules/rive-runtime/skia/dependencies
-        run: ./make_skia_macos.sh arm64
+        run: |
+          # make_skia_macos.sh finishes by uploading its build cache to Rive's own
+          # S3 bucket (s3://2d-public/archives), which we have no credentials for.
+          # That upload exits non-zero and would fail the step even though the
+          # build succeeded, so ignore the script's status and assert on the
+          # artifact CMakeLists.txt actually links against instead.
+          ./make_skia_macos.sh arm64 || echo "make_skia_macos.sh exited non-zero (expected: S3 cache upload)"
+          test -f skia/out/macosx/arm64/libskia.a
+          ls -lh skia/out/macosx/arm64/libskia.a
 
       - name: Configure
         run: cmake -B native/rive-desktop/build -S native/rive-desktop -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/build-native-desktop.yml
+++ b/.github/workflows/build-native-desktop.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Configure
         run: cmake -B native/rive-desktop/build -S native/rive-desktop -DCMAKE_BUILD_TYPE=Release
 
+      - name: Locate the static libs Premake produced
+        run: |
+          # CMake links against native/rive-desktop/out/<arch>_<config>/lib*.a.
+          # Show where build_rive.sh actually wrote them so a path mismatch is
+          # diagnosable from the log rather than by guesswork.
+          find submodules/rive-runtime native/rive-desktop -name 'librive*.a' 2>/dev/null | head -40 || true
+          echo "--- expected by CMake ---"
+          ls -la native/rive-desktop/out/arm64_release/ 2>/dev/null || echo "(missing)"
+
       - name: Build
         run: cmake --build native/rive-desktop/build
 

--- a/native/rive-desktop/CMakeLists.txt
+++ b/native/rive-desktop/CMakeLists.txt
@@ -53,6 +53,11 @@ target_compile_definitions(rive-desktop PRIVATE
 target_compile_definitions(rive-desktop PRIVATE
         SK_DISABLE_SKPICTURE
         SK_DISABLE_TEXT
+        # Skia's SHARED_EXTRA_CFLAGS in make_skia_macos.sh also sets RIVE_OPTIMIZED.
+        # Omitting it here compiles Skia's headers differently than Skia itself was
+        # compiled, so SkCanvas's layout disagrees and the first SkCanvas::save()
+        # segfaults at runtime.
+        RIVE_OPTIMIZED
         SK_DISABLE_LEGACY_SHADERCONTEXT
         SK_DISABLE_LOWP_RASTER_PIPELINE
         SK_FORCE_RASTER_PIPELINE_BLITTER

--- a/native/rive-desktop/CMakeLists.txt
+++ b/native/rive-desktop/CMakeLists.txt
@@ -19,17 +19,19 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
 add_library(rive-desktop SHARED ${SOURCES})
 
 # List of static libraries
-# These must match what `build_rive.sh ... -- rive_cpp_runtime` emits into
-# out/<arch>_<config>. The pinned rive-runtime does not produce
-# rive_pls_renderer, and the bridge renders through Skia's CPU rasterizer so
-# references no PLS/Rive Renderer symbols. librive_cpp_runtime.a is deliberately
-# not linked either: it is an aggregate archive containing the other .a files as
-# members, which ld rejects ("librive.a not a mach-o file"). Link the components.
+# These must match what the premake invocation below emits into
+# out/<arch>_<config>. rive_pls_renderer is required even though this bridge
+# renders through Skia's CPU rasterizer: with WITH_SCRIPTING=ON, librive.a's
+# Luau shader bindings reference rive::gpu::RenderContext and RiveRenderer.
+# librive_cpp_runtime.a is deliberately not listed - it is an aggregate archive
+# whose members are these .a files, which ld rejects ("librive.a not a mach-o
+# file"). Link the components instead.
 set(static_libs
         rive
         rive_harfbuzz
         rive_sheenbidi
         rive_yoga
+        rive_pls_renderer
 )
 
 # Enable C++17
@@ -149,7 +151,7 @@ set_target_properties(rive-desktop PROPERTIES
 
 # Build the Rive C++ runtime and its dependencies as static .a libs
 execute_process(
-        COMMAND bash ${RIVE_RUNTIME_DIR}/build/build_rive.sh --file=premake5_cpp_runtime.lua ninja ${CONFIG} ${RIVE_ARCH} --no-rive-decoders --with_rive_audio=${RIVE_AUDIO_ARG} ${RIVE_SCRIPTING_ARG} ${RIVE_ASAN_FLAG} -- rive_cpp_runtime
+        COMMAND bash ${RIVE_RUNTIME_DIR}/build/build_rive.sh --file=premake5_cpp_runtime.lua ninja ${CONFIG} ${RIVE_ARCH} --no-rive-decoders --with_rive_audio=${RIVE_AUDIO_ARG} ${RIVE_SCRIPTING_ARG} ${RIVE_ASAN_FLAG} -- rive_cpp_runtime rive_pls_renderer
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         RESULT_VARIABLE SCRIPT_RESULT
         OUTPUT_VARIABLE SCRIPT_OUTPUT

--- a/native/rive-desktop/CMakeLists.txt
+++ b/native/rive-desktop/CMakeLists.txt
@@ -19,16 +19,17 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
 add_library(rive-desktop SHARED ${SOURCES})
 
 # List of static libraries
-# These must match what `build_rive.sh ... -- rive_cpp_runtime` actually emits
-# into out/<arch>_<config>. The pinned rive-runtime builds rive_cpp_runtime and
-# does not produce rive_pls_renderer; the bridge renders through Skia's CPU
-# rasterizer and references no PLS/Rive Renderer symbols.
+# These must match what `build_rive.sh ... -- rive_cpp_runtime` emits into
+# out/<arch>_<config>. The pinned rive-runtime does not produce
+# rive_pls_renderer, and the bridge renders through Skia's CPU rasterizer so
+# references no PLS/Rive Renderer symbols. librive_cpp_runtime.a is deliberately
+# not linked either: it is an aggregate archive containing the other .a files as
+# members, which ld rejects ("librive.a not a mach-o file"). Link the components.
 set(static_libs
         rive
         rive_harfbuzz
         rive_sheenbidi
         rive_yoga
-        rive_cpp_runtime
 )
 
 # Enable C++17

--- a/native/rive-desktop/CMakeLists.txt
+++ b/native/rive-desktop/CMakeLists.txt
@@ -19,12 +19,16 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
 add_library(rive-desktop SHARED ${SOURCES})
 
 # List of static libraries
+# These must match what `build_rive.sh ... -- rive_cpp_runtime` actually emits
+# into out/<arch>_<config>. The pinned rive-runtime builds rive_cpp_runtime and
+# does not produce rive_pls_renderer; the bridge renders through Skia's CPU
+# rasterizer and references no PLS/Rive Renderer symbols.
 set(static_libs
         rive
         rive_harfbuzz
         rive_sheenbidi
         rive_yoga
-        rive_pls_renderer
+        rive_cpp_runtime
 )
 
 # Enable C++17

--- a/native/rive-desktop/CMakeLists.txt
+++ b/native/rive-desktop/CMakeLists.txt
@@ -53,8 +53,10 @@ target_compile_definitions(rive-desktop PRIVATE
         SK_DISABLE_EFFECT_DESERIALIZATION)
 
 # Configure for monorepo vs. rive-desktop repo
-if (EXISTS "${PROJECT_SOURCE_DIR}/../submodules/rive-runtime")
-    set(PACKAGES_DIR "${PROJECT_SOURCE_DIR}/..")
+if (EXISTS "${PROJECT_SOURCE_DIR}/../../submodules/rive-runtime")
+    # PROJECT_SOURCE_DIR is native/rive-desktop, so the repo root - which is where
+    # submodules/rive-runtime lives - is two levels up, not one.
+    set(PACKAGES_DIR "${PROJECT_SOURCE_DIR}/../..")
     set(RIVE_RUNTIME_DIR "${PACKAGES_DIR}/submodules/rive-runtime")
 else ()
     set(PACKAGES_DIR "${PROJECT_SOURCE_DIR}/../../../../..")


### PR DESCRIPTION
Follow-up to #150. The native build workflow added there had never been run. Dispatching it took **eight runs** and surfaced **five genuine defects** — three of them in the native build itself, not in the workflow.

The final run is [green](https://github.com/muazkadan/Rive-CMP/actions/runs/34530928772): Skia builds, the bridge links, and the JNI smoke test passes against the freshly built binary.

## What was broken

| # | Defect | Fix |
|---|---|---|
| 1 | Skia's vendored zlib `#define fdopen(fd,mode) NULL` breaks against the macOS 15.5 SDK's own `fdopen` declaration | run on `macos-14` (Xcode 15.4 / SDK 14.5) |
| 2 | `make_skia_macos.sh` ends by uploading its cache to Rive's private `s3://2d-public`, exits non-zero without credentials | ignore its status, assert on `libskia.a` |
| 3 | `if (EXISTS "${PROJECT_SOURCE_DIR}/../submodules/rive-runtime")` tests `native/submodules/...`; the submodule is at the repo root, two levels up | correct the path |
| 4 | premake asked ninja only for `rive_cpp_runtime`, so `librive_pls_renderer.a` was never produced — but the link needs it | request `rive_pls_renderer` too |
| 5 | `librive_cpp_runtime.a` is an aggregate archive whose members are the other `.a` files; `ld` rejects it (`'librive.a' not a mach-o file`) | link the components, not the aggregate |

**Defects 3–5 mean this native build has never worked from a clean checkout of this repository.** It only ever succeeded against one machine's local layout and a pre-existing `out/` directory — which is why a prebuilt `.dylib` was committed instead. Nothing in the Gradle build configures the native project, so nothing caught it.

### On #4 — why PLS is required

The bridge rasterises on the CPU through Skia and references no PLS symbols of its own, so `rive_pls_renderer` looks like a stale list entry. It isn't. With `WITH_SCRIPTING=ON` (the default), `librive.a`'s Luau shader bindings reference the GPU renderer:

```
rive::gpu::RenderContext::beginFrame(...)
rive::gpu::RiveRenderer::RiveRenderer(rive::gpu::RenderContext*)
   referenced from: ..._namecall(lua_State*) in lto.o
```

Building with `-DWITH_SCRIPTING=OFF` would also link, but would produce a dylib without scripting support — quite possibly diverging from what is currently shipped. Matching the shipped feature set seemed the better default; that flag remains available.

## Provenance status

The run produced a binary and compared it against the committed one:

```
committed: baf660c9323d08239e464278cbcec2ffa4bc5129658473a5f8477f3bb5a2aab3
built:     7b8a175114c959eb1a1cbf9b8e82242ac8b45adc20a5284382241dea69801874
```

They differ, exactly as `native/rive-desktop/README.md` predicts — the shipped dylib predates the pin. **This PR does not replace it.** Swapping in a binary built from a different `rive-runtime` commit can change runtime behaviour, so that should be a deliberate commit with the desktop sample exercised against the new binary first.

> [!NOTE]
> The commit history includes two dead ends (`a2a4da0`, `e53584f`) where the `static_libs` list was wrong before the linker named the real cause. They are candidates for squashing; the net diff is 15 lines of CMake and the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of macOS desktop builds across supported hardware and SDK configurations.
  - Fixed native build configuration issues that could cause runtime rendering crashes.
  - Added safeguards to ensure required native libraries are generated and available during builds.
  - Improved diagnostics for identifying missing or misplaced native build outputs.

- **Chores**
  - Updated desktop build configuration to use a compatible macOS build environment.
  - Improved compatibility between the desktop renderer and its supporting native libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
