### PR TITLE
Refresh README for 0.4.1, desktop support and the new toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ use rive-android, rive-ios, and @rive-app/canvas seamlessly across Android, iOS,
 | Web (JS/Wasm) | NPM package               | `@rive-app/canvas`        |
 | Desktop (JVM) | Custom JNI bridge to rive-runtime (C++) | none (bundled native library) |
 
+> [!IMPORTANT]
+> **The iOS simulator on Intel Macs is not supported as of 0.4.1.** Compose Multiplatform stopped
+> publishing an `iosX64` variant in 1.11, so that target can no longer be built. `iosArm64` (devices)
+> and `iosSimulatorArm64` (Apple Silicon simulators) are unaffected. Stay on `0.4.0` if you need
+> the Intel simulator.
+
 **Desktop (JVM) is currently macOS arm64 only.** There is no official Rive SDK for JVM/Desktop,
 so this bridges directly to the C++ [rive-runtime](https://github.com/rive-app/rive-runtime) via
 JNI, rendering through Skia's CPU rasterizer. Linux, Windows, and macOS x64 have the CMake build
@@ -60,7 +66,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 commonMain.dependencies {
-    implementation("dev.muazkadan:rive-cmp:0.4.0")
+    implementation("dev.muazkadan:rive-cmp:0.4.1")
 }
 ```
 
@@ -68,7 +74,7 @@ commonMain.dependencies {
 
 ```kotlin
 dependencies {
-    implementation("dev.muazkadan:rive-cmp:0.4.0")
+    implementation("dev.muazkadan:rive-cmp:0.4.1")
 }
 ```
 
@@ -78,7 +84,7 @@ Add to your `libs.versions.toml`:
 
 ```toml
 [versions]
-rive-cmp = "0.4.0"
+rive-cmp = "0.4.1"
 
 [libraries]
 rive-cmp = { module = "dev.muazkadan:rive-cmp", version.ref = "rive-cmp" }
@@ -317,30 +323,45 @@ fun rememberRiveComposition(
 ### Android
 
 - Minimum SDK: 24
-- Compile/Target SDK: 36
-- Kotlin: 2.0+
-- Compose Multiplatform: 1.10+
-- AGP: 9.0+ (Gradle 9.1+)
+- Compile/Target SDK: 37
+- Kotlin: 2.4+
+- Compose Multiplatform: 1.12+
+- AGP: 9.3.2+ (Gradle 9.7+)
+
+> Kotlin 2.4+ is a hard floor, not a recommendation: the published artifacts are built with
+> Kotlin 2.4.20, and consumers on 2.3.x will hit Kotlin metadata incompatibilities.
 
 ### iOS
 
 - Minimum iOS: 14.0
 - Xcode: 15+
 - Swift: 5.9+
+- Apple Silicon required for simulator builds (see the `iosX64` note above)
 
-### Web (JS)
+### Web (JS/Wasm)
 
-- Compose Multiplatform: 1.9.0+
+- Compose Multiplatform: 1.12+
 - Kotlin/JS with IR compiler
 - Browser environment
 
+### Desktop (JVM)
+
+- macOS arm64 only
+- JDK 11+
+
 ## Building
 
-The project has three modules:
+The project has four Gradle modules:
 
-- **`library`** – The Rive CMP library (KMP with Android, iOS, JS)
-- **`sample`** – Shared sample UI and logic (KMP library; used by Android and iOS)
+- **`library`** – The Rive CMP library (KMP: Android, iOS, JS, Wasm, JVM/Desktop)
+- **`sample`** – Shared sample UI and logic (KMP library; also the Desktop, JS and Wasm entry point)
 - **`androidSample`** – Android app entry point (run this for the Android sample)
+- **`runtime-macos-arm64`** – Ships the prebuilt `librive-desktoparm64.dylib` for JVM/Desktop
+
+plus **`native/rive-desktop/`**, a CMake project for the JNI bridge. It is *not* part of the default
+Gradle build - `:library:jvmMain` consumes the prebuilt binary instead. See
+[`native/rive-desktop/README.md`](native/rive-desktop/README.md) for how to build it, the pinned
+`rive-runtime` commit, and the provenance of the shipped binary.
 
 The library uses Kotlin Multiplatform with the following plugins:
 
@@ -351,18 +372,31 @@ The library uses Kotlin Multiplatform with the following plugins:
 - `spmForKmp` (for iOS Swift Package Manager integration)
 
 ```bash
-# Build all targets
-./gradlew build
+# Build and run the Android sample app
+./gradlew :androidSample:installDebug
+
+# Run the Desktop (JVM) sample
+./gradlew :sample:run
+
+# Run the Wasm sample in a browser (http://localhost:8080)
+./gradlew :sample:wasmJsBrowserDevelopmentRun
+
+# Run the JS sample in a browser (http://localhost:8080)
+./gradlew :sample:jsBrowserDevelopmentRun
 
 # Build Android AAR
 ./gradlew :library:assembleRelease
 
-# Build and run the Android sample app
-./gradlew :androidSample:installDebug
-
 # Build iOS Framework
 ./gradlew :library:linkReleaseFrameworkIosArm64
 ```
+
+> [!NOTE]
+> `./gradlew build` currently fails on `checkComposeUiTestConfigurationForJs` /
+> `...ForWasmJs`, a Compose Multiplatform 1.12 check
+> ([CMP-4906](https://youtrack.jetbrains.com/issue/CMP-4906)) whose suggested fix conflicts with the
+> `binaries.library()` output this project publishes. Assembling, publishing and running the
+> samples are unaffected - use the per-target tasks above.
 
 To run the sample in Android Studio, use the **androidSample** run configuration (not `sample`).
 
@@ -380,6 +414,14 @@ To run the sample in Android Studio, use the **androidSample** run configuration
 2. Open in Android Studio or IntelliJ IDEA
 3. Sync Gradle dependencies
 4. For iOS development, ensure Xcode is installed
+5. Only if you intend to build the native desktop bridge, fetch the pinned Rive runtime:
+
+   ```bash
+   git submodule update --init --recursive submodules/rive-runtime
+   ```
+
+   This is not needed for normal development - the JVM target uses the prebuilt binary in
+   `runtime-macos-arm64`. The checkout and its Skia build are large (several GB).
 
 ## License
 

--- a/native/rive-desktop/README.md
+++ b/native/rive-desktop/README.md
@@ -21,6 +21,19 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ```
 
+Requires `ninja` and `premake` (`brew install ninja premake`).
+
+Two known snags on recent macOS:
+
+- `make_skia_macos.sh` invokes `python`, which no longer exists on macOS 26 (only `python3`). Put a
+  `python` shim on `PATH` that execs `python3` - a symlink does not work, because `/usr/bin/python3`
+  resolves the tool from `argv[0]`.
+- The Skia this pins is from 2022 and its vendored zlib and libpng take Classic Mac OS code paths
+  under `TARGET_OS_MAC`, so they fail against modern SDKs (`fdopen` redefinition, missing `fp.h`).
+  It builds against the macOS 14.5 SDK; the
+  [Build native desktop runtime](../../.github/workflows/build-native-desktop.yml) workflow uses
+  `macos-14` for this reason.
+
 Produces `build/librive-desktop<arch>.<ext>` for the host OS/arch.
 
 ## Scope


### PR DESCRIPTION
The README still described 0.4.0 and a three-module Android/iOS/JS project, so most of its version numbers had drifted.

## Changes

| Area | Was | Now |
|---|---|---|
| Dependency snippets (×3) | `0.4.0` | `0.4.1` |
| Compile/Target SDK | 36 | 37 |
| Kotlin | 2.0+ | 2.4+ |
| Compose Multiplatform | 1.10+ / 1.9.0+ | 1.12+ |
| AGP / Gradle | 9.0+ / 9.1+ | 9.3.2+ / 9.7+ |
| Modules | "three modules" | four, plus `native/rive-desktop` |

## Notable additions

- **Intel Mac iOS simulator is unsupported as of 0.4.1.** Compose Multiplatform stopped publishing `iosX64` in 1.11, so an Intel user upgrading gets a dependency-resolution failure with nothing in the docs explaining it. Called out in Platform Support and Requirements.
- **Kotlin 2.4+ is a hard floor**, not a recommendation — the artifacts are built with 2.4.20 and 2.3.x consumers hit metadata incompatibilities.
- **`./gradlew build` currently fails** on `checkComposeUiTestConfigurationFor{Js,WasmJs}` ([CMP-4906](https://youtrack.jetbrains.com/issue/CMP-4906)). It was the first command in the Building section, so a newcomer's first command errored out and looked like a broken repo. Now noted, with per-target tasks listed first.
- **Run commands for Desktop, JS and Wasm samples** — the desktop target shipped with no documented way to run it.
- **Submodule step in Development Setup** — the repo gained `submodules/rive-runtime`, and setup still said "clone the repository". Flagged as only needed for the native bridge, since the checkout plus its Skia build is several GB.
- **`runtime-macos-arm64`** is now described, with a link to `native/rive-desktop/README.md` for the pinned commit and the provenance of the shipped binary.
- **Two macOS snags recorded in the native README**: `python` no longer exists on macOS 26 (only `python3`, and a symlink doesn't work because `/usr/bin/python3` resolves from `argv[0]`), and the 2022-era pinned Skia only builds against older SDKs.

## Intentionally unchanged

The experimental / "may be discontinued" disclaimer at the top and the `Copyright 2025` line are left as-is. Both are editorial decisions about the project rather than stale facts, so they are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and dependency examples for version 0.4.1.
  * Documented updated requirements, including Android SDK 37, Kotlin 2.4+, Compose Multiplatform 1.12+, AGP 9.3.2+, and Gradle 9.7+.
  * iOS simulator support now requires Apple Silicon; Intel simulators are unsupported from 0.4.1.
  * Clarified target-specific build commands, module coverage, runtime setup, and known macOS build requirements and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
