### PR TITLE
Include Desktop (JVM) in the project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 <img alt="Platform Android" src="https://img.shields.io/badge/Platform-Android-brightgreen"/>
 <img alt="Platform iOS" src="https://img.shields.io/badge/Platform-iOS-lightgray"/>
 <img alt="Platform Web" src="https://img.shields.io/badge/Platform-Web%20(JS%2FWasm)-orange"/>
+<img alt="Platform Desktop" src="https://img.shields.io/badge/Platform-Desktop%20(JVM)-blueviolet"/>
 
 A Compose Multiplatform wrapper library for integrating Rive animations, providing a unified API to
-use rive-android, rive-ios, and @rive-app/canvas seamlessly across Android, iOS, and Web platforms.
+use rive-android, rive-ios, @rive-app/canvas, and a JNI bridge to rive-runtime seamlessly across
+Android, iOS, Web, and Desktop platforms.
 
 <img src="images/banner.png" alt="Rive CMP Banner"></img>
 
@@ -29,12 +31,12 @@ use rive-android, rive-ios, and @rive-app/canvas seamlessly across Android, iOS,
 
 ## Features
 
-- **Unified API**: Single `CustomRiveAnimation` composable that works across Android, iOS and Web
+- **Unified API**: Single `CustomRiveAnimation` composable that works across Android, iOS, Web and Desktop
 - **Multiple Loading Options**: Load animations from URLs, ByteArrays, or pre-composed
   specifications
 - **Native Performance**: Uses platform-specific Rive implementations for optimal performance
 - **Easy Integration**: Simple Compose-style API with familiar modifier patterns
-- **State Machine Support**: Support for Rive state machines on both platforms
+- **State Machine Support**: Support for Rive state machines on every supported platform
 - **Flexible Configuration**: Customizable alignment, fit, artboard selection, and playback options
 - **Memory Efficient**: Value classes and immutable specifications for optimal performance
 
@@ -455,4 +457,5 @@ limitations under the License.
 - [rive-android](https://github.com/rive-app/rive-android) for Android implementation
 - [rive-ios](https://github.com/rive-app/rive-ios) for iOS implementation
 - [@rive-app/canvas](https://www.npmjs.com/package/@rive-app/canvas) for Web implementation
+- [rive-runtime](https://github.com/rive-app/rive-runtime) for the C++ runtime behind Desktop (JVM)
 - [spm4kmp](https://github.com/frankois944/spm4kmp) for Swift Package Manager integration

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -115,7 +115,7 @@ mavenPublishing {
     pom {
         name = "Rive CMP"
         description =
-            "A Compose Multiplatform wrapper library for integrating Rive animations, providing a unified API to use rive-android and rive-ios seamlessly across Android and iOS platforms."
+            "A Compose Multiplatform wrapper library for integrating Rive animations, providing a unified API to use rive-android, rive-ios, @rive-app/canvas, and a JNI bridge to rive-runtime seamlessly across Android, iOS, Web, and Desktop platforms."
         inceptionYear = "2025"
         url = "https://github.com/muazkadan/Rive-CMP"
         licenses {


### PR DESCRIPTION
Desktop support landed in #148, but the project still described itself as Android/iOS/Web in the places people read first. #156 refreshed the body of the README and missed the headline.

## Changes

| Location | Was | Now |
|---|---|---|
| README tagline | "across Android, iOS, and Web platforms" | adds Desktop and the JNI bridge to rive-runtime |
| Platform badges | Android, iOS, Web | adds Desktop (JVM) |
| Features → Unified API | "Android, iOS and Web" | adds Desktop |
| Features → State Machine Support | "on both platforms" | "on every supported platform" |
| Acknowledgments | android / ios / canvas | adds `rive-runtime` |
| **Maven Central POM description** | "rive-android and rive-ios ... across Android and iOS platforms" | all four platforms |

## Note on the POM description

`library/build.gradle.kts` was the worst of these — it omitted **Web as well as Desktop**, so it had been stale since JS/Wasm support shipped in 0.4.0. That string is published to Maven Central with every release and appears on the artifact's listing page, so it is the description most consumers encounter before ever reaching the repository.

It takes effect on the next publish; the metadata already on Maven Central for 0.4.1 and earlier is immutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to include Desktop (JVM) as a supported platform.
  * Clarified cross-platform integrations and the JNI bridge to the Rive runtime.
  * Expanded feature descriptions and acknowledgments to cover Desktop support.
  * Updated the Maven package description with the latest platform and integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->