### PR TITLE
Publish :library and :runtime-macos-arm64 from one version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,10 @@
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+
+GROUP=dev.muazkadan
+VERSION_NAME=0.4.1
+
 #Kotlin
 kotlin.code.style=official
 #MPP

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
-group = "dev.muazkadan"
-version = "0.4.1"
+group = providers.gradleProperty("GROUP").get()
+version = providers.gradleProperty("VERSION_NAME").get()
 kotlin {
     compilerOptions {
         freeCompilerArgs.add("-opt-in=kotlin.concurrent.atomics.ExperimentalAtomicApi")
@@ -110,7 +110,8 @@ mavenPublishing {
 
     signAllPublications()
 
-    coordinates(group.toString(), "rive-cmp", version.toString())
+    // groupId and version come from GROUP / VERSION_NAME in gradle.properties
+        coordinates(artifactId = "rive-cmp")
 
     pom {
         name = "Rive CMP"

--- a/runtime-macos-arm64/build.gradle.kts
+++ b/runtime-macos-arm64/build.gradle.kts
@@ -3,15 +3,16 @@ plugins {
     alias(libs.plugins.vanniktech.mavenPublish)
 }
 
-group = "dev.muazkadan"
-version = "0.4.0"
+group = providers.gradleProperty("GROUP").get()
+version = providers.gradleProperty("VERSION_NAME").get()
 
 mavenPublishing {
     publishToMavenCentral()
 
     signAllPublications()
 
-    coordinates(group.toString(), "rive-cmp-runtime-macos-arm64", version.toString())
+    // groupId and version come from GROUP / VERSION_NAME in gradle.properties
+    coordinates(artifactId = "rive-cmp-runtime-macos-arm64")
 
     pom {
         name = "Rive CMP Desktop Runtime (macOS arm64)"


### PR DESCRIPTION
Blocks any release that includes the JVM/Desktop target.

## The problem

`runtime-macos-arm64/build.gradle.kts` hardcoded `version = "0.4.0"` while `:library` was on `0.4.1`. Since `:library`'s jvm variant carries

```kotlin
runtimeOnly(project(":runtime-macos-arm64"))
```

that skew publishes a POM pointing at a coordinate that is never released. And `rive-cmp-runtime-macos-arm64` does not exist on Maven Central **at any version**:

```
dev/muazkadan/rive-cmp                      -> 0.3.3, 0.3.4, 0.4.0, 0.4.1
dev/muazkadan/rive-cmp-runtime-macos-arm64  -> HTTP 404
```

So a JVM/Desktop consumer of the next release would fail to resolve the native library. Desktop support would appear to ship and then not work.

## The fix

`GROUP` and `VERSION_NAME` move into `gradle.properties`, which the maven-publish plugin already reads natively, and `coordinates()` now passes only the artifactId. Bumping one property moves both modules and the dependency between them.

## Verification

`publishToMavenLocal` produces a `rive-cmp-jvm` POM with:

```xml
<artifactId>rive-cmp-runtime-macos-arm64</artifactId>
<version>0.4.1</version>
<scope>runtime</scope>
```

and re-running with `-PVERSION_NAME=0.5.0-alpha01` moves both modules **and** the dependency to `0.5.0-alpha01`, so the versions can no longer drift apart.

> [!IMPORTANT]
> Publishing a release must now cover both modules. A root `./gradlew publishToMavenCentral` does; publishing `:library` alone does not, and would recreate the unresolvable-dependency problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)