### PR TITLE
Clear the desktop frame buffer so transparency is preserved

### DIFF
--- a/library/src/jvmMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.jvm.kt
+++ b/library/src/jvmMain/kotlin/dev/muazkadan/rivecmp/CustomRiveAnimation.jvm.kt
@@ -165,6 +165,8 @@ private class RiveRendererNode(
 
     var overlay: Boolean = overlay
 
+    private val TRANSPARENT = 0
+
     private var bitmap: Bitmap? = null
     private var imageBitmap: ImageBitmap? = null
 
@@ -202,6 +204,10 @@ private class RiveRendererNode(
             while (isActive) {
                 withFrameMillis { frameTime ->
                     if (controller.artboardRenderer.isPlaying) {
+                        // Rive draws only the artboard's shapes into the bitmap and never
+                        // clears it, so anything transparent in this frame would otherwise
+                        // keep showing the previous frame's pixels.
+                        bitmap?.erase(TRANSPARENT)
                         controller.artboardRenderer.doFrame((frameTime - lastFrameTime) / 1_000f)
                         bitmap?.notifyPixelsChanged()
                         invalidateDraw()


### PR DESCRIPTION
Animations with transparent regions smeared on JVM/Desktop. In the sample, as the alligator opens and closes its mouth, the mouth's previous position stays visible instead of showing what is behind it.

## Cause

`CanvasRenderer` binds Skia directly to the bitmap's pixel memory and Rive draws only the artboard's shapes into it. **Nothing clears the buffer between frames**, so every pixel that is transparent in the current frame keeps whatever the previous frame left there.

Opaque areas looked correct because they are overwritten every frame, which is why this survived since desktop support was first written.

## Fix

Erase the bitmap before advancing:

```kotlin
bitmap?.erase(TRANSPARENT)
controller.artboardRenderer.doFrame(...)
```

A memset per frame is negligible next to rasterising the artboard.

> [!NOTE]
> This could equally live in `CanvasRenderer` as a `clear()` before drawing, which is arguably its more natural home. That would require rebuilding and re-verifying the native library for an identical result, so the Kotlin side was preferred; the native option remains open as a later tidy-up.

## Verification

Run in the desktop sample against `alligator_swipe.riv` — transparency is preserved through the mouth animation.

## Related

This is the third defect of the same family on desktop — colour channels (#150), row stride (#161), and now frame clearing — all cases of the Kotlin and native sides disagreeing about what happens to the shared pixel buffer. #161 is the place to address that contract properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved animation rendering by clearing transparent areas before each frame, preventing visual artifacts from previous frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->